### PR TITLE
Fixed SimLogger conversion from decimal to percent

### DIFF
--- a/src/edu/boun/edgecloudsim/utils/SimLogger.java
+++ b/src/edu/boun/edgecloudsim/utils/SimLogger.java
@@ -1244,7 +1244,7 @@ SimSettings.DELIMITER;
 		totalMipsUtil = 0;
 		for (int i = 0; i < fogLayerAvgMipsUtil.length; i++) {
 			//printLine("\tLevel " + (i + 1) + ": " + String.format("%.6f", ((double)fogLayerAvgNwUtil[i])));
-			printLine("\tLevel " + (i + 1) + ": " + String.format("%.2f", ((double)fogLayerAvgNwUtil[i] / 100)) + " %"); // / 100?
+			printLine("\tLevel " + (i + 1) + ": " + String.format("%.2f", ((double)fogLayerAvgNwUtil[i] * 100)) + " %");
 			totalMipsUtil += (double)fogLayerAvgMipsUtil[i];
 		}
 


### PR DESCRIPTION
In SimLogger, a decmial was converted to percent using /100, where I believe it should have been *100. This change increases the average fog node utilization for each layer in the results; see the attached file as an example. 
I'm not sure what a nominal run looks like, so I'm assuming those utlization numbers are correct, but they may not be. 
[Centralized_100_Devices.txt](https://github.com/roy-harmon/PFogSim-v3/files/7758392/Centralized_100_Devices.txt)

 